### PR TITLE
Check for valac-Major.Minor

### DIFF
--- a/vala/FindVala.cmake
+++ b/vala/FindVala.cmake
@@ -44,8 +44,9 @@
 # either expressed or implied, of Jakob Westhoff
 ##
 
-# Search for the valac executable in the usual system paths.
-find_program(VALA_EXECUTABLE valac)
+# Search for the valac executable in the usual system paths
+# Some distributions rename the valac to contain the major.minor in the binary name
+find_program(VALA_EXECUTABLE NAMES valac valac-0.20 valac-0.18 valac-0.16 valac-0.14 valac 0.12 valac 0.10)
 mark_as_advanced(VALA_EXECUTABLE)
 
 # Determine the valac version


### PR DESCRIPTION
This is needed because some distributions do not provide valac bu only ie valac-0.14.

In reality the named distro should fix their distribution, but we should try bit to build as it is not that complex to contain this.
