### PR TITLE
FindVala.cmake: fixed incorrect valac-executable names

### DIFF
--- a/vala/FindVala.cmake
+++ b/vala/FindVala.cmake
@@ -46,7 +46,7 @@
 
 # Search for the valac executable in the usual system paths
 # Some distributions rename the valac to contain the major.minor in the binary name
-find_program(VALA_EXECUTABLE NAMES valac valac-0.20 valac-0.18 valac-0.16 valac-0.14 valac 0.12 valac 0.10)
+find_program(VALA_EXECUTABLE NAMES valac valac-0.20 valac-0.18 valac-0.16 valac-0.14 valac-0.12 valac-0.10)
 mark_as_advanced(VALA_EXECUTABLE)
 
 # Determine the valac version


### PR DESCRIPTION
Patch should explain itself. Fixes, that FindVala recognizes executables named 0.12 and 0.10 as valac-executables.
